### PR TITLE
Lab5 - add tx error monitor

### DIFF
--- a/orchagent/Makefile.am
+++ b/orchagent/Makefile.am
@@ -92,7 +92,8 @@ orchagent_SOURCES = \
             lagid.cpp \
             bfdorch.cpp \
             srv6orch.cpp \
-            response_publisher.cpp
+            response_publisher.cpp \
+            txmonitororch.cpp
 
 orchagent_SOURCES += flex_counter/flex_counter_manager.cpp flex_counter/flex_counter_stat_manager.cpp flex_counter/flow_counter_handler.cpp
 orchagent_SOURCES += debug_counter/debug_counter.cpp debug_counter/drop_counter.cpp

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -319,18 +319,9 @@ bool OrchDaemon::init()
 
     gNhgMapOrch = new NhgMapOrch(m_applDb, APP_FC_TO_NHG_INDEX_MAP_TABLE_NAME);
 
-    //TODO:
-    /*
+
         TableConnector configueTxTableConnector(m_configDb,CFG_PORT_TX_ERROR_TABLE_NAME);
         TableConnector stateTxTableConnector(m_stateDb,STATE_PORT_TX_ERROR_TABLE_NAME);
-        DBConnector counterDB(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
-        TableConnector countersTableConnector(&counterDB,COUNTERS_TABLE);
-        gTxMonitorOrch = &TxMonitorOrch::getInstance(configueTxTableConnector,
-                                                     stateTxTableConnector,
-                                                     countersTableConnector);
-                                                     */
-        TableConnector configueTxTableConnector(m_configDb,"CFG_PORT_TX_ERROR_TABLE");
-        TableConnector stateTxTableConnector(m_stateDb,"STATE_PORT_TX_ERROR_TABLE");
         DBConnector counterDB(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         TableConnector countersTableConnector(&counterDB,COUNTERS_TABLE);
         TableConnector interfaceToOidTableConnector(&counterDB,COUNTERS_PORT_NAME_MAP);

--- a/orchagent/orchdaemon.cpp
+++ b/orchagent/orchdaemon.cpp
@@ -333,9 +333,11 @@ bool OrchDaemon::init()
         TableConnector stateTxTableConnector(m_stateDb,"STATE_PORT_TX_ERROR_TABLE");
         DBConnector counterDB(COUNTERS_DB, DBConnector::DEFAULT_UNIXSOCKET, 0);
         TableConnector countersTableConnector(&counterDB,COUNTERS_TABLE);
+        TableConnector interfaceToOidTableConnector(&counterDB,COUNTERS_PORT_NAME_MAP);
         gTxMonitorOrch = &TxMonitorOrch::getInstance(configueTxTableConnector,
                                                      stateTxTableConnector,
-                                                     countersTableConnector);
+                                                     countersTableConnector,
+                                                     interfaceToOidTableConnector);
     /*
      * The order of the orch list is important for state restore of warm start and
      * the queued processing in m_toSync map after gPortsOrch->allPortsReady() is set.

--- a/orchagent/orchdaemon.h
+++ b/orchagent/orchdaemon.h
@@ -43,6 +43,7 @@
 #include "p4orch/p4orch.h"
 #include "bfdorch.h"
 #include "srv6orch.h"
+#include "txmonitororch.h"
 
 using namespace swss;
 

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -2573,6 +2573,7 @@ void PortsOrch::doPortTask(Consumer &consumer)
                 addSystemPorts();
                 m_initDone = true;
                 SWSS_LOG_INFO("Get PortInitDone notification from portsyncd.");
+                SWSS_LOG_NOTICE("TxMonitorOrchLogs: Get PortInitDone notification from portsyncd.");
             }
 
             it = consumer.m_toSync.erase(it);
@@ -6490,6 +6491,7 @@ bool PortsOrch::getRecircPort(Port &port, string role)
 
 bool PortsOrch::addSystemPorts()
 {
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: in portsorc, addSystemPorts");
     vector<string> keys;
     vector<FieldValueTuple> spFv;
 
@@ -6533,10 +6535,12 @@ bool PortsOrch::addSystemPorts()
 
         if(system_port_id < 0 || switch_id < 0 || core_index < 0 || core_port_index < 0)
         {
+            SWSS_LOG_NOTICE("TxMonitorOrchLogs: in addSystemPorts in if statment");
             SWSS_LOG_ERROR("Invalid or Missing field values for %s! system_port id:%d, switch_id:%d, core_index:%d, core_port_index:%d",
                     alias.c_str(), system_port_id, switch_id, core_index, core_port_index);
             continue;
         }
+        SWSS_LOG_NOTICE("TxMonitorOrchLogs: in addSystemPorts after if statment");
 
         tuple<int, int, int> sp_key(switch_id, core_index, core_port_index);
 
@@ -6550,6 +6554,7 @@ bool PortsOrch::addSystemPorts()
 
             //Retrive system port config info and enable
             system_port_oid = m_systemPortOidMap[sp_key];
+            SWSS_LOG_NOTICE("TxMonitorOrchLogs: in portsorc, oid is: %lu", system_port_oid);
 
             attr.id = SAI_SYSTEM_PORT_ATTR_TYPE;
             attrs.push_back(attr);
@@ -6625,7 +6630,9 @@ bool PortsOrch::addSystemPorts()
             //System port does not exist in the switch
             //This can not happen since all the system ports are supposed to be created during switch creation itself
 
-            SWSS_LOG_ERROR("System port %s does not exist in switch. Port not added!", alias.c_str());
+            SWSS_LOG_ERROR("System port %s does not exist in switch. Poruh8t not added!", alias.c_str());
+            SWSS_LOG_NOTICE("TxMonitorOrchLogs: in portsorc, addSystemPorts hereeee");
+
             continue;
         }
     }

--- a/orchagent/portsorch.cpp
+++ b/orchagent/portsorch.cpp
@@ -4927,7 +4927,7 @@ bool PortsOrch::addLag(string lag_alias, uint32_t spa_id, int32_t switch_id)
     auto lagport = m_portList.find(lag_alias);
     if (lagport != m_portList.end())
     {
-        /* The deletion of bridgeport attached to the lag may still be 
+        /* The deletion of bridgeport attached to the lag may still be
          * pending due to fdb entries still present on the lag. Wait
          * until the cleanup is done.
          */

--- a/orchagent/txmonitororch.cpp
+++ b/orchagent/txmonitororch.cpp
@@ -54,17 +54,18 @@ TxMonitorOrch::TxMonitorOrch(TableConnector cfgTxTblConnector,
 
 void TxMonitorOrch::initCfgTxTbl(){
     /*
-     table name: "CFG_PORT_TX_ERROR_TABLE" "values"
+     table name: "CFG_PORT_TX_ERROR_TABLE" "Config"
      "polling_period"
      <period value>
      "threshold"
      <threshold value>
      */
-
+    SWSS_LOG_ENTER();
     vector<FieldValueTuple> fvs;
     fvs.emplace_back("polling_period", std::to_string(m_pollPeriod));
     fvs.emplace_back("threshold",std::to_string(m_threshold));
-    m_cfgTxTbl->set("values",fvs);
+    m_cfgTxTbl->set("Config",fvs);
+    SWSS_LOG_NOTICE("Init CFG_PORT_TX_ERROR_TABLE with default values");
 }
 
 void TxMonitorOrch::initPortsErrorStatisticsMap(){

--- a/orchagent/txmonitororch.cpp
+++ b/orchagent/txmonitororch.cpp
@@ -1,0 +1,145 @@
+#include "txmonitororch.h"
+//TODO: try to understand why to take it as global and why not initialize
+extern PortsOrch* gPortsOrch;
+
+TxMonitorOrch& TxMonitorOrch::getInstance(TableConnector configueTxTableConnector,
+                                          TableConnector stateTxTableConnector,
+                                          TableConnector countersTableConnector)
+{
+    SWSS_LOG_ENTER();
+    static TxMonitorOrch* txMonitorOrch = new TxMonitorOrch(configueTxTableConnector,
+                                                            stateTxTableConnector,
+                                                            countersTableConnector);
+    return *txMonitorOrch;
+}
+
+
+// TODO: change the m_pollPeriod and m_threshold from default values to the configurable values
+TxMonitorOrch::TxMonitorOrch(TableConnector configueTxTableConnector,
+                             TableConnector stateTxTableConnector,
+                             TableConnector countersTableConnector):
+    Orch(configueTxTableConnector.first, configueTxTableConnector.second),
+    m_configueTxTable(configueTxTableConnector.first,
+                      configueTxTableConnector.second),
+    m_stateTxTable(stateTxTableConnector.first,
+                   stateTxTableConnector.second),
+    m_countersTable(countersTableConnector.first, countersTableConnector.second),
+    m_pollPeriod{DEFAULT_POLLPERIOD},
+    m_threshold{DEFAULT_THRESHOLD}
+{
+
+    SWSS_LOG_ENTER();
+    auto interv = timespec { .tv_sec = m_pollPeriod, .tv_nsec = 0 };
+    auto timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(timer, this, "MC_TX_ERROR_COUNTERS_POLL");
+    Orch::addExecutor(executor);
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: 2 TxMonitorOrch initialized with the tables: %s, %s, %s\n",
+                    configueTxTableConnector.second.c_str(),
+                    stateTxTableConnector.second.c_str(),
+                    countersTableConnector.second.c_str());
+
+
+    timer->start();
+}
+
+std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> TxMonitorOrch::createPortsErrorStatisticsMap(){
+
+    SWSS_LOG_ENTER();
+    std::map<std::string, TxPortErrorStatistics*> interfaceToPortErrorStatistics{};
+    map<string, Port> &interfaceToPort =  gPortsOrch->getAllPorts();
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: interfaceToPort size: %lu", interfaceToPort.size());
+
+        for (auto &entry : interfaceToPort)
+        {
+
+            string interface = entry.first;
+            SWSS_LOG_NOTICE("TxMonitorOrchLogs: interface name: %s", interface.c_str());
+            Port p = entry.second;
+            if (p.m_type != Port::PHY)
+            {
+                continue;
+            }
+            std::string oidStr = std::to_string(p.m_system_port_oid);
+            SWSS_LOG_NOTICE("TxMonitorOrchLogs: oid: %s", oidStr.c_str());
+
+
+            interfaceToPortErrorStatistics[interface]=new TxPortErrorStatistics(oidStr);
+
+        }
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: create txMonitorOrch map");
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: The number of interfaces in txMonitorOrch map: %lu",
+                    interfaceToPortErrorStatistics.size());
+    m_isPortsMapInitialized=true;
+    return interfaceToPortErrorStatistics;
+
+    }
+
+void TxMonitorOrch::printPortsErrorStatistics(){
+    for(auto it = m_interfaceToPortErrorStatistics.cbegin(); it != m_interfaceToPortErrorStatistics.cend(); ++it)
+    {
+        std::string interface = it->first;
+        std::string portStatistics = it->second->to_string();
+        SWSS_LOG_NOTICE("TxMonitorOrchLogs: %s\t\t%s",interface.c_str(),portStatistics.c_str());
+
+    }
+}
+
+TxMonitorOrch::~TxMonitorOrch(void){
+    SWSS_LOG_ENTER();
+}
+
+void TxMonitorOrch::updateStateDB(std::string currOid,std::string status){
+    SWSS_LOG_ENTER();
+    vector<FieldValueTuple> fvs;
+    fvs.emplace_back("status", status);
+    m_stateTxTable.set(currOid, fvs);
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: update stateDB txErrorTable at key oid: %s with the new status  %s", currOid.c_str(), status.c_str());
+}
+
+
+
+void TxMonitorOrch::doTask(SelectableTimer &timer){
+    SWSS_LOG_ENTER();
+    if(!gPortsOrch->allPortsReady()){
+        return;
+    }
+
+    m_interfaceToPortErrorStatistics = createPortsErrorStatisticsMap();
+    printPortsErrorStatistics();
+    for(const auto& entry : m_interfaceToPortErrorStatistics){
+
+        std::string interface = entry.first;
+        SWSS_LOG_NOTICE("TxMonitorOrchLogs: check statistics and update for interface: %s.\n",interface.c_str());
+
+        TxPortErrorStatistics* currTxStatistics = entry.second;
+        SWSS_LOG_NOTICE("TxMonitorOrchLogs: last tx counter: %s\n",std::to_string(currTxStatistics->errorCount).c_str());
+
+        std::string currOid = currTxStatistics->m_oid;
+        if(currOid=="0"){
+            return;
+        }
+        u_int64_t newErrorCount = getNewErrorCount(currOid);
+
+        bool newIsOk = getIsOkStatus(newErrorCount, currTxStatistics->errorCount);
+        if(newIsOk != currTxStatistics->isOk){
+            currTxStatistics->isOk = newIsOk;
+            updateStateDB(currOid, currTxStatistics->getStatus());
+
+        }
+        currTxStatistics->errorCount = newErrorCount;
+
+    }
+}
+
+u_int64_t TxMonitorOrch::getNewErrorCount(std::string currOid){
+    std::string newErrorCountStr;
+    m_countersTable.hget(currOid, "SAI_PORT_STAT_IF_OUT_ERRORS",newErrorCountStr);
+    SWSS_LOG_NOTICE("TxMonitorOrchLogs: new tx counter: %s\n",newErrorCountStr.c_str());
+    return stoul(newErrorCountStr);
+}
+
+bool TxMonitorOrch::getIsOkStatus(u_int64_t newErrorCount, u_int64_t currErrorCount){
+    SWSS_LOG_ENTER();
+    return (currErrorCount-newErrorCount) < this->m_threshold;
+}
+//TODO: take care in case configure change in runtime

--- a/orchagent/txmonitororch.cpp
+++ b/orchagent/txmonitororch.cpp
@@ -17,7 +17,6 @@ TxMonitorOrch& TxMonitorOrch::getInstance(TableConnector cfgTxTblConnector,
 }
 
 
-// TODO: change the m_pollPeriod and m_threshold from default values to the configurable values
 TxMonitorOrch::TxMonitorOrch(TableConnector cfgTxTblConnector,
                              TableConnector stateTxTblConnector,
                              TableConnector cntrTblConnector,
@@ -39,8 +38,8 @@ TxMonitorOrch::TxMonitorOrch(TableConnector cfgTxTblConnector,
                                                ifToOidTblConnector.second));
     initCfgTxTbl();
     auto interv = timespec { .tv_sec = m_pollPeriod, .tv_nsec = 0 };
-    auto timer = new SelectableTimer(interv);
-    auto executor = new ExecutableTimer(timer, this, TX_TIMER_NAME);
+    m_timer = new SelectableTimer(interv);
+    auto executor = new ExecutableTimer(m_timer, this, TX_TIMER_NAME);
     Orch::addExecutor(executor);
     SWSS_LOG_NOTICE("TxMonitorOrch initialized with the tables: %s, %s, %s, %s\n",
                     cfgTxTblConnector.second.c_str(),
@@ -49,10 +48,11 @@ TxMonitorOrch::TxMonitorOrch(TableConnector cfgTxTblConnector,
                     ifToOidTblConnector.second.c_str());
 
 
-    timer->start();
+    m_timer->start();
 }
 
-void TxMonitorOrch::initCfgTxTbl(){
+void TxMonitorOrch::initCfgTxTbl()
+{
     /*
      table name: "CFG_PORT_TX_ERROR_TABLE" "Config"
      "polling_period"
@@ -68,18 +68,19 @@ void TxMonitorOrch::initCfgTxTbl(){
     SWSS_LOG_NOTICE("Init CFG_PORT_TX_ERROR_TABLE with default values");
 }
 
-void TxMonitorOrch::initPortsErrorStatisticsMap(){
+void TxMonitorOrch::initPortsErrorStatisticsMap()
+{
 
     SWSS_LOG_ENTER();
     map<string, Port> &ifToPort =  gPortsOrch->getAllPorts();
-    m_ifToTxPortErrStat = make_shared<IfToTxPortErrStat>();
+    m_ifToTxPortErrStat = new IfToTxPortErrStat();
     std::string oidStr;
     for (auto &entry : ifToPort)
     {
         string interface = entry.first;
         Port p = entry.second;
 
-        SWSS_LOG_NOTICE("interface name: %s", interface.c_str());
+        SWSS_LOG_DEBUG("interface name: %s", interface.c_str());
         if(p.m_type != Port::PHY)
         {
             continue;
@@ -87,28 +88,28 @@ void TxMonitorOrch::initPortsErrorStatisticsMap(){
 
         if(m_ifToOidTbl->hget("",interface,oidStr))
         {
-            SWSS_LOG_NOTICE("oid: %s", oidStr.c_str());
-            SWSS_LOG_NOTICE("eden new mark to delete");
-            m_ifToTxPortErrStat->emplace(interface, make_shared<TxPortErrStat>(oidStr));
-            SWSS_LOG_NOTICE("eden after insertion ");
+            SWSS_LOG_DEBUG("oid: %s", oidStr.c_str());
+            m_ifToTxPortErrStat->emplace(interface, TxPortErrStat(oidStr));
             updateStateDB(oidStr.c_str(),true);
         }
         else
         {
-            //todo:warning
-            SWSS_LOG_NOTICE("cant get oid for interface %s", interface.c_str());
-            m_ifToTxPortErrStat->emplace(interface,make_unique<TxPortErrStat>());
+            SWSS_LOG_WARN("cant get oid for interface %s", interface.c_str());
+            m_ifToTxPortErrStat->emplace(interface,TxPortErrStat());
         }
 
     }
     SWSS_LOG_NOTICE("create txMonitorOrch map");
 }
 
-TxMonitorOrch::~TxMonitorOrch(void){
+TxMonitorOrch::~TxMonitorOrch(void)
+{
     SWSS_LOG_ENTER();
+    delete m_ifToTxPortErrStat;
 }
 
-void TxMonitorOrch::updateStateDB(std::string currOid,bool is_ok){
+void TxMonitorOrch::updateStateDB(std::string currOid,bool is_ok)
+{
     SWSS_LOG_ENTER();
     vector<FieldValueTuple> fvs;
     std::string status;
@@ -125,23 +126,25 @@ void TxMonitorOrch::updateStateDB(std::string currOid,bool is_ok){
     SWSS_LOG_NOTICE("update stateDB txErrorTable at key oid: %s with the new status  %s", currOid.c_str(), status.c_str());
 }
 
-std::string TxMonitorOrch::getOid(std::string interface){
+std::string TxMonitorOrch::getOid(std::string interface)
+{
 
     std::string oidStr;
     if(m_ifToOidTbl->hget("",interface,oidStr))
     {
-        SWSS_LOG_NOTICE("oid: %s", oidStr.c_str());
+        SWSS_LOG_DEBUG("oid: %s", oidStr.c_str());
         return oidStr;
     }
     else
     {
-        SWSS_LOG_NOTICE("cant get oid for interfae %s", interface.c_str());
+        SWSS_LOG_WARN("cant get oid for interfae %s", interface.c_str());
         return std::string{};
     }
 }
 
 
-bool TxMonitorOrch::getNewErrorCount(std::string currOid, u_int64_t& newErrorCount){
+bool TxMonitorOrch::getNewErrorCount(std::string currOid, u_int64_t& newErrorCount)
+{
 
     std::string newErrorCountStr;
     m_cntrTbl->hget(currOid, "SAI_PORT_STAT_IF_OUT_ERRORS",newErrorCountStr);
@@ -160,75 +163,159 @@ bool TxMonitorOrch::getNewErrorCount(std::string currOid, u_int64_t& newErrorCou
 
 
 
-bool TxMonitorOrch::getIsOkStatus(u_int64_t newErrorCount, u_int64_t currErrorCount){
+bool TxMonitorOrch::getIsOkStatus(u_int64_t newErrorCount, u_int64_t currErrorCount)
+{
     SWSS_LOG_ENTER();
-    return (currErrorCount-newErrorCount) < m_threshold;
+    SWSS_LOG_DEBUG("New error count: [%lu]", newErrorCount);
+    SWSS_LOG_DEBUG("Curr error count: [%lu]", currErrorCount);
+    SWSS_LOG_DEBUG("Curr threshold: [%u]", m_threshold);
+
+    return (newErrorCount-currErrorCount) < m_threshold;
 }
 
-void TxMonitorOrch::poolTxErrorStatistics(){
+void TxMonitorOrch::poolTxErrorStatistics()
+{
     SWSS_LOG_ENTER();
-    SWSS_LOG_NOTICE("eden before loop");
-    if(!m_ifToTxPortErrStat){
-        SWSS_LOG_NOTICE("eden map is null");
-
-    }
-
-    /*IfToTxPortErrStat map = *m_ifToTxPortErrStat;
-    SWSS_LOG_NOTICE("eden map.size is: %u", map.size());
-    IfToTxPortErrStat::iterator it;
-    for(it = map.begin(); it != map.end(); it++){
-        SWSS_LOG_NOTICE("eden in loop");
-    }
-    */
-    SWSS_LOG_NOTICE("eden map.size is: %lu", (*m_ifToTxPortErrStat).size());
     for( auto& entry : *m_ifToTxPortErrStat){
-        SWSS_LOG_NOTICE("eden 5");
         std::string interface = entry.first;
-
-        SWSS_LOG_NOTICE("Check statistics and update for interface [%s]",interface.c_str());
-        //todo share ptr?
-        std::shared_ptr<TxPortErrStat> currTxStatistics = entry.second;
-        std::string currOid = currTxStatistics->m_oid;
+        SWSS_LOG_DEBUG("Check statistics and update for interface [%s]",interface.c_str());
+        TxPortErrStat& currTxStatistics = entry.second;
+        std::string currOid = currTxStatistics.m_oid;
         if(currOid==string{})
         {
-            currTxStatistics->m_oid =getOid(interface);
-            if(currTxStatistics->m_oid == string{})
+            currTxStatistics.m_oid =getOid(interface);
+            if(currTxStatistics.m_oid == string{})
             {
-                //todo warnning
+                SWSS_LOG_WARN("Faild get oid for %s interface", interface.c_str());
                 return;
             }
-            updateStateDB(currTxStatistics->m_oid,true);
+            updateStateDB(currTxStatistics.m_oid,true);
         }
 
-        u_int64_t currErrorCount = currTxStatistics->m_errorCount;
+        u_int64_t currErrorCount = currTxStatistics.m_errorCount;
         SWSS_LOG_NOTICE("last tx counter: %s\n",std::to_string(currErrorCount).c_str());
         u_int64_t newErrorCount = currErrorCount;
         if(getNewErrorCount(currOid, newErrorCount))
         {
            bool newIsOk = getIsOkStatus(newErrorCount, currErrorCount);
-           if(newIsOk != currTxStatistics->m_isOk)
+           if(newIsOk != currTxStatistics.m_isOk)
            {
-               currTxStatistics->m_isOk = newIsOk;
+               currTxStatistics.m_isOk = newIsOk;
                updateStateDB(currOid, newIsOk);
 
            }
         }
-        currTxStatistics->m_errorCount = newErrorCount;
+        currTxStatistics.m_errorCount = newErrorCount;
     }
 
 }
 
-void TxMonitorOrch::doTask(SelectableTimer &timer){
-    SWSS_LOG_NOTICE("eden do task 11");
+void TxMonitorOrch::doTask(SelectableTimer &timer)
+{
     SWSS_LOG_ENTER();
     if(!m_ifToTxPortErrStat)
     {
-        SWSS_LOG_NOTICE("eden do task 22");
         initPortsErrorStatisticsMap();
     }
-    SWSS_LOG_NOTICE("eden do task 33");
     poolTxErrorStatistics();
 }
 
+void TxMonitorOrch::setTimer()
+{
+    auto interval = timespec { .tv_sec = m_pollPeriod, .tv_nsec = 0 };
+    m_timer->setInterval(interval);
+    m_timer->reset();
+}
 
-//TODO: take care in case configure change in runtime
+void TxMonitorOrch::handlePeriodUpdate(std::string newValue)
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("update period update");
+
+    try
+    {
+        uint32_t newPeriod = to_uint<uint32_t>(newValue);
+        if(m_pollPeriod != newPeriod){
+            m_pollPeriod = newPeriod;
+            SWSS_LOG_DEBUG("m_pollPeriod set [%u]", m_pollPeriod);
+            setTimer();
+        }
+    }
+    catch(const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Period is a number but got %s", newValue.c_str());
+        SWSS_LOG_ERROR("runtime Eerror %s", e.what());
+    }
+}
+
+void TxMonitorOrch::handleThresholdUpdate(std::string newValue)
+{
+    SWSS_LOG_ENTER();
+    SWSS_LOG_NOTICE("Handle threshold update");
+    try
+    {
+        m_threshold = to_uint<uint32_t>(newValue);
+        SWSS_LOG_DEBUG("m_threshold set [%u]", m_threshold);
+    }
+    catch(const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Threshold is a number but got %s", newValue.c_str());
+        SWSS_LOG_ERROR("runtime Eerror %s", e.what());
+    }
+
+}
+void TxMonitorOrch::handleConfigUpdate(std::vector<FieldValueTuple> fvs)
+{
+    SWSS_LOG_NOTICE("Handle configure update");
+    for(FieldValueTuple fv : fvs)
+    {
+        std::string field = fvField(fv);
+        std::string value = fvValue(fv);
+
+        if(field == "polling_period")
+        {
+           handlePeriodUpdate(value);
+        }
+        else if(field == "threshold")
+        {
+            handleThresholdUpdate(value);
+        }
+        else
+        {
+            SWSS_LOG_ERROR("Unexpected field");
+        }
+    }
+
+}
+
+void TxMonitorOrch::doTask(Consumer &consumer)
+{
+    SWSS_LOG_ENTER();
+    try
+    {
+        auto it = consumer.m_toSync.begin();
+        while(it!=consumer.m_toSync.end()){
+
+            KeyOpFieldsValuesTuple currEvent= it->second;
+            std::string key = kfvKey(currEvent);
+            std::string op = kfvOp(currEvent);
+
+            if(key == "Config" && op == SET_COMMAND)
+            {
+                handleConfigUpdate(kfvFieldsValues(currEvent));
+            }
+            else
+            {
+                SWSS_LOG_ERROR("Unexpected operation or key");
+            }
+            consumer.m_toSync.erase(it++);
+        }
+    }
+    catch(const std::exception& e)
+    {
+        SWSS_LOG_ERROR("Runtime error: %s", e.what());
+    }
+}
+
+
+

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -11,7 +11,7 @@
 
 class TxPortErrStat{
     public:
-        TxPortErrStat(std::string oid = "null"):m_oid(oid){};
+        TxPortErrStat(std::string oid = std::string{}):m_oid(oid){};
     private:
         bool m_isOk{true};
         std::string m_oid{};
@@ -55,8 +55,7 @@ class TxMonitorOrch: public Orch
         void poolTxErrorStatistics();
         bool getIsOkStatus(u_int64_t, u_int64_t);
         void updateStateDB(std::string, bool);
-        u_int64_t getNewErrorCount(std::string currOid);
-
+        bool getNewErrorCount(std::string currOid, u_int64_t& newErrorCount);
 
 };
 

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -7,8 +7,31 @@
 
 #define DEFAULT_POLLPERIOD 30
 #define DEFAULT_THRESHOLD 5
+
+class TxPortErrStat{
+    public:
+        bool m_isOk{true};
+        std::string m_oid{};
+        u_int64_t m_errorCount{};
+        TxPortErrStat(std::string oid = "null"):m_oid(oid){}
+        std::string getStatus(){
+            if(m_isOk){
+                return "ok";
+            }
+            return "not-ok";
+        }
+        std::string to_string(){
+            return "status: " + getStatus() + "\n" +
+                    "oid: " + m_oid +
+                    "tx errors: " + std::to_string(m_errorCount) + "\n";
+        }
+};
+
+typedef std::map<std::string, TxPortErrStat*> IFtoTxPortErrStat;
+
 class TxMonitorOrch: public Orch
 {
+
 
     public:
         static TxMonitorOrch& getInstance(TableConnector configueTxTableConnector,
@@ -17,30 +40,12 @@ class TxMonitorOrch: public Orch
                                           TableConnector interfaceToOidTableConnector);
 
         //void printPortsErrorStatistics(std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> interfaceToPortErrorStatistics);
+
         virtual void doTask(swss::SelectableTimer &timer);
         virtual void doTask(Consumer &consumer){}
 
     private:
-        //todo: is ok change to function.. change to is ok to status string
-        //to add m to fields
-        class TxPortErrorStatistics{
-            public:
-                bool isOk{true};
-                std::string m_oid{};
-                u_int64_t errorCount{};
-                TxPortErrorStatistics(std::string oid):m_oid(oid){}
-                std::string getStatus(){
-                    if(isOk){
-                        return "ok";
-                    }
-                    return "not-ok";
-                }
-                std::string to_string(){
-                    return "status: " + getStatus() + "\n" +
-                            "oid: " + m_oid +
-                            "tx errors: " + std::to_string(errorCount) + "\n";
-                }
-        };
+
 
         swss::Table m_configueTxTable;
         swss::Table m_stateTxTable;
@@ -48,13 +53,16 @@ class TxMonitorOrch: public Orch
         swss::Table m_interfaceToOidTable;
         u_int32_t m_pollPeriod;
         u_int32_t m_threshold;
-        bool m_isPortsMapInitialized{};
-        std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> createPortsErrorStatisticsMap();
+        IFtoTxPortErrStat createPortsErrorStatisticsMap();
+        void initConfigTxTable();
         TxMonitorOrch(TableConnector configueTxTableConnectorr,
                       TableConnector stateTxTableConnector,
                       TableConnector countersTableConnector,
                       TableConnector interfaceToOidTableConnector);
+
         virtual ~TxMonitorOrch(void);
+        std::string getOid(std::string interface);
+        void poolTxErrorStatistics(std::string interface,TxPortErrStat* currTxStatistics);
         bool getIsOkStatus(u_int64_t, u_int64_t);
         void updateStateDB(std::string, std::string);
         u_int64_t getNewErrorCount(std::string currOid);

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -1,0 +1,63 @@
+#ifndef SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_
+#define SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_
+
+#include "orch.h"
+#include "portsorch.h"
+#include "countercheckorch.h"
+
+#define DEFAULT_POLLPERIOD 30
+#define DEFAULT_THRESHOLD 5
+class TxMonitorOrch: public Orch
+{
+
+    public:
+        static TxMonitorOrch& getInstance(TableConnector configueTxTableConnector,
+                                          TableConnector stateTxTableConnector,
+                                          TableConnector countersTableConnector);
+
+        void printPortsErrorStatistics();
+        virtual void doTask(swss::SelectableTimer &timer);
+        virtual void doTask(Consumer &consumer){}
+
+    private:
+        //todo: is ok change to function.. change to is ok to status string
+        //to add m to fields
+        class TxPortErrorStatistics{
+            public:
+                bool isOk{true};
+                std::string m_oid{};
+                u_int64_t errorCount{};
+                TxPortErrorStatistics(std::string oid):m_oid(oid){}
+                std::string getStatus(){
+                    if(isOk){
+                        return "ok";
+                    }
+                    return "not-ok";
+                }
+                std::string to_string(){
+                    return "status: " + getStatus() + "\n" +
+                            "oid: " + m_oid +
+                            "tx errors: " + std::to_string(errorCount) + "\n";
+                }
+        };
+
+        swss::Table m_configueTxTable;
+        swss::Table m_stateTxTable;
+        swss::Table m_countersTable;
+        u_int32_t m_pollPeriod;
+        u_int32_t m_threshold;
+        std::map<std::string, TxPortErrorStatistics*> m_interfaceToPortErrorStatistics{};
+        bool m_isPortsMapInitialized{};
+        std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> createPortsErrorStatisticsMap();
+        TxMonitorOrch(TableConnector configueTxTableConnectorr,
+                      TableConnector stateTxTableConnector,
+                      TableConnector countersTableConnector);
+        virtual ~TxMonitorOrch(void);
+        bool getIsOkStatus(u_int64_t, u_int64_t);
+        void updateStateDB(std::string, std::string);
+        u_int64_t getNewErrorCount(std::string currOid);
+
+
+};
+
+#endif /* SONIC_SWSS_ORCHAGENT_TXMONITORORCH_H_ */

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -11,29 +11,19 @@
 
 class TxPortErrStat{
     public:
+        TxPortErrStat(std::string oid = "null"):m_oid(oid){};
+    private:
         bool m_isOk{true};
         std::string m_oid{};
         u_int64_t m_errorCount{};
-        TxPortErrStat(std::string oid = "null"):m_oid(oid){}
-        std::string getStatus(){
-            if(m_isOk){
-                return "ok";
-            }
-            return "not-ok";
-        }
-        std::string to_string(){
-            return "status: " + getStatus() + "\n" +
-                    "oid: " + m_oid +
-                    "tx errors: " + std::to_string(m_errorCount) + "\n";
-        }
+
+        friend class TxMonitorOrch;
 };
 
-typedef std::map<std::string, std::shared_ptr<TxPortErrStat>> IFtoTxPortErrStat;
+typedef std::map<std::string, std::shared_ptr<TxPortErrStat>> IfToTxPortErrStat;
 
 class TxMonitorOrch: public Orch
 {
-
-
     public:
         static TxMonitorOrch& getInstance(TableConnector cfgTxTblConnector,
                                           TableConnector stateTxTblConnector,
@@ -46,14 +36,14 @@ class TxMonitorOrch: public Orch
 
     private:
 
-
         unique_ptr<swss::Table> m_cfgTxTbl;
         unique_ptr<swss::Table> m_stateTxTbl;
         unique_ptr<swss::Table> m_cntrTbl;
         unique_ptr<swss::Table> m_ifToOidTbl;
-        u_int32_t m_pollPeriod;
-        u_int32_t m_threshold;
-        IFtoTxPortErrStat createPortsErrorStatisticsMap();
+        uint32_t m_pollPeriod;
+        uint32_t m_threshold;
+        shared_ptr<IfToTxPortErrStat> m_ifToTxPortErrStat;
+        void initPortsErrorStatisticsMap();
         void initCfgTxTbl();
         TxMonitorOrch(TableConnector cfgTxTblConnectorr,
                       TableConnector stateTxTblConnector,
@@ -62,9 +52,9 @@ class TxMonitorOrch: public Orch
 
         virtual ~TxMonitorOrch(void);
         std::string getOid(std::string interface);
-        void poolTxErrorStatistics(std::string interface,std::shared_ptr<TxPortErrStat> currTxStatistics);
+        void poolTxErrorStatistics();
         bool getIsOkStatus(u_int64_t, u_int64_t);
-        void updateStateDB(std::string, std::string);
+        void updateStateDB(std::string, bool);
         u_int64_t getNewErrorCount(std::string currOid);
 
 

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -13,9 +13,10 @@ class TxMonitorOrch: public Orch
     public:
         static TxMonitorOrch& getInstance(TableConnector configueTxTableConnector,
                                           TableConnector stateTxTableConnector,
-                                          TableConnector countersTableConnector);
+                                          TableConnector countersTableConnector,
+                                          TableConnector interfaceToOidTableConnector);
 
-        void printPortsErrorStatistics();
+        //void printPortsErrorStatistics(std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> interfaceToPortErrorStatistics);
         virtual void doTask(swss::SelectableTimer &timer);
         virtual void doTask(Consumer &consumer){}
 
@@ -44,14 +45,15 @@ class TxMonitorOrch: public Orch
         swss::Table m_configueTxTable;
         swss::Table m_stateTxTable;
         swss::Table m_countersTable;
+        swss::Table m_interfaceToOidTable;
         u_int32_t m_pollPeriod;
         u_int32_t m_threshold;
-        std::map<std::string, TxPortErrorStatistics*> m_interfaceToPortErrorStatistics{};
         bool m_isPortsMapInitialized{};
         std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> createPortsErrorStatisticsMap();
         TxMonitorOrch(TableConnector configueTxTableConnectorr,
                       TableConnector stateTxTableConnector,
-                      TableConnector countersTableConnector);
+                      TableConnector countersTableConnector,
+                      TableConnector interfaceToOidTableConnector);
         virtual ~TxMonitorOrch(void);
         bool getIsOkStatus(u_int64_t, u_int64_t);
         void updateStateDB(std::string, std::string);

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -9,6 +9,7 @@
 #define DEFAULT_THRESHOLD 5
 #define TX_TIMER_NAME "MC_TX_ERROR_COUNTERS_POLL"
 
+
 class TxPortErrStat{
     public:
         TxPortErrStat(std::string oid = std::string{}):m_oid(oid){};
@@ -20,7 +21,7 @@ class TxPortErrStat{
         friend class TxMonitorOrch;
 };
 
-typedef std::map<std::string, std::shared_ptr<TxPortErrStat>> IfToTxPortErrStat;
+typedef std::map<std::string, TxPortErrStat> IfToTxPortErrStat;
 
 class TxMonitorOrch: public Orch
 {
@@ -32,7 +33,7 @@ class TxMonitorOrch: public Orch
 
 
         virtual void doTask(swss::SelectableTimer &timer);
-        virtual void doTask(Consumer &consumer){}
+        virtual void doTask(Consumer &consumer);
 
     private:
 
@@ -40,9 +41,10 @@ class TxMonitorOrch: public Orch
         unique_ptr<swss::Table> m_stateTxTbl;
         unique_ptr<swss::Table> m_cntrTbl;
         unique_ptr<swss::Table> m_ifToOidTbl;
+        SelectableTimer* m_timer = nullptr;
         uint32_t m_pollPeriod;
         uint32_t m_threshold;
-        shared_ptr<IfToTxPortErrStat> m_ifToTxPortErrStat;
+        IfToTxPortErrStat* m_ifToTxPortErrStat;
         void initPortsErrorStatisticsMap();
         void initCfgTxTbl();
         TxMonitorOrch(TableConnector cfgTxTblConnectorr,
@@ -56,6 +58,10 @@ class TxMonitorOrch: public Orch
         bool getIsOkStatus(u_int64_t, u_int64_t);
         void updateStateDB(std::string, bool);
         bool getNewErrorCount(std::string currOid, u_int64_t& newErrorCount);
+        void setTimer();
+        void handleConfigUpdate(std::vector<FieldValueTuple> fvs);
+        void handlePeriodUpdate(std::string newValue);
+        void handleThresholdUpdate(std::string newValue);
 
 };
 

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -27,7 +27,7 @@ class TxPortErrStat{
         }
 };
 
-typedef std::map<std::string, TxPortErrStat*> IFtoTxPortErrStat;
+typedef std::map<std::string, std::shared_ptr<TxPortErrStat>> IFtoTxPortErrStat;
 
 class TxMonitorOrch: public Orch
 {
@@ -39,7 +39,6 @@ class TxMonitorOrch: public Orch
                                           TableConnector countersTableConnector,
                                           TableConnector interfaceToOidTableConnector);
 
-        //void printPortsErrorStatistics(std::map<std::string, TxMonitorOrch::TxPortErrorStatistics*> interfaceToPortErrorStatistics);
 
         virtual void doTask(swss::SelectableTimer &timer);
         virtual void doTask(Consumer &consumer){}
@@ -62,7 +61,7 @@ class TxMonitorOrch: public Orch
 
         virtual ~TxMonitorOrch(void);
         std::string getOid(std::string interface);
-        void poolTxErrorStatistics(std::string interface,TxPortErrStat* currTxStatistics);
+        void poolTxErrorStatistics(std::string interface,std::shared_ptr<TxPortErrStat> currTxStatistics);
         bool getIsOkStatus(u_int64_t, u_int64_t);
         void updateStateDB(std::string, std::string);
         u_int64_t getNewErrorCount(std::string currOid);

--- a/orchagent/txmonitororch.h
+++ b/orchagent/txmonitororch.h
@@ -7,6 +7,7 @@
 
 #define DEFAULT_POLLPERIOD 30
 #define DEFAULT_THRESHOLD 5
+#define TX_TIMER_NAME "MC_TX_ERROR_COUNTERS_POLL"
 
 class TxPortErrStat{
     public:
@@ -34,10 +35,10 @@ class TxMonitorOrch: public Orch
 
 
     public:
-        static TxMonitorOrch& getInstance(TableConnector configueTxTableConnector,
-                                          TableConnector stateTxTableConnector,
-                                          TableConnector countersTableConnector,
-                                          TableConnector interfaceToOidTableConnector);
+        static TxMonitorOrch& getInstance(TableConnector cfgTxTblConnector,
+                                          TableConnector stateTxTblConnector,
+                                          TableConnector cntrTblConnector,
+                                          TableConnector ifToOidTblConnector);
 
 
         virtual void doTask(swss::SelectableTimer &timer);
@@ -46,18 +47,18 @@ class TxMonitorOrch: public Orch
     private:
 
 
-        swss::Table m_configueTxTable;
-        swss::Table m_stateTxTable;
-        swss::Table m_countersTable;
-        swss::Table m_interfaceToOidTable;
+        unique_ptr<swss::Table> m_cfgTxTbl;
+        unique_ptr<swss::Table> m_stateTxTbl;
+        unique_ptr<swss::Table> m_cntrTbl;
+        unique_ptr<swss::Table> m_ifToOidTbl;
         u_int32_t m_pollPeriod;
         u_int32_t m_threshold;
         IFtoTxPortErrStat createPortsErrorStatisticsMap();
-        void initConfigTxTable();
-        TxMonitorOrch(TableConnector configueTxTableConnectorr,
-                      TableConnector stateTxTableConnector,
-                      TableConnector countersTableConnector,
-                      TableConnector interfaceToOidTableConnector);
+        void initCfgTxTbl();
+        TxMonitorOrch(TableConnector cfgTxTblConnectorr,
+                      TableConnector stateTxTblConnector,
+                      TableConnector cntrTblConnector,
+                      TableConnector ifToOidTblConnector);
 
         virtual ~TxMonitorOrch(void);
         std::string getOid(std::string interface);

--- a/tests/mock_tests/Makefile.am
+++ b/tests/mock_tests/Makefile.am
@@ -87,7 +87,8 @@ tests_SOURCES = aclorch_ut.cpp \
                 $(top_srcdir)/orchagent/macsecorch.cpp \
                 $(top_srcdir)/orchagent/lagid.cpp \
                 $(top_srcdir)/orchagent/bfdorch.cpp \
-                $(top_srcdir)/orchagent/srv6orch.cpp
+                $(top_srcdir)/orchagent/srv6orch.cpp \
+                $(top_srcdir)/orchagent/txmonitororch.cpp
 
 tests_SOURCES += $(FLEX_CTR_DIR)/flex_counter_manager.cpp $(FLEX_CTR_DIR)/flex_counter_stat_manager.cpp $(FLEX_CTR_DIR)/flow_counter_handler.cpp
 tests_SOURCES += $(DEBUG_CTR_DIR)/debug_counter.cpp $(DEBUG_CTR_DIR)/drop_counter.cpp


### PR DESCRIPTION
<!--
Please make sure you have read and understood the contribution guildlines:
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

1. Make sure your commit includes a signature generted with `git commit -s`
2. Make sure your commit title follows the correct format: [component]: description
3. Make sure your commit message contains enough details about the change and related tests
4. Make sure your pull request adds related reviewers, asignees, labels

Please also provide the following information in this pull request:
-->

**What I did**

Add new orch agent txmonitororch. the txmonitor orch monitor the tx errors on switch ports. In case the number of  errors on one port in a configurable time period reaches the configurable thresholds , port is deemed as “Not OK”. 

**Why I did it**

In order to get the status of the tx for each port in the switch.

**How I verified it**

enter the following CLI commands:
test 1:
1. show tx-error-monitor status 
2. choose one oid of port with the status "ok"
3. stop the counters:
    counterpoll port disable
4. set the tx counter of the port to be above threshold:
     redis-cli -n 2 HSET COUNTERS:oid:<oid> SAI_PORT_STAT_IF_OUT_ERRORS "200"
5. verify that the status of the port change to not ok: 
     show tx-error-monitor status
test 2:
1. show tx-error-monitor status 
2. choose one oid of port with the status "ok"
3. stop the counters:
    counterpoll port disable
4. set the threshold to 200:
    config tx-config threshold 200
6. set the tx counter of the port to be above threshold:
     redis-cli -n 2 HSET COUNTERS:oid:<oid> SAI_PORT_STAT_IF_OUT_ERRORS "200"
7. verify that the status of the port is still ok: 
     show tx-error-monitor status

**Details if related**
